### PR TITLE
schema: add ColumnElement to Column.server_default

### DIFF
--- a/sqlalchemy-stubs/sql/schema.pyi
+++ b/sqlalchemy-stubs/sql/schema.pyi
@@ -25,6 +25,7 @@ from .base import DialectKWArgs
 from .base import SchemaEventTarget
 from .elements import ClauseElement
 from .elements import ColumnClause
+from .elements import ColumnElement
 from .elements import TextClause
 from .selectable import TableClause
 from .. import util
@@ -125,7 +126,9 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
     primary_key: bool = ...
     nullable: bool = ...
     default: Optional[Any] = ...
-    server_default: Optional[Union[FetchedValue, str, TextClause]] = ...
+    server_default: Optional[
+        Union[FetchedValue, str, TextClause, ColumnElement[_TE]]
+    ] = ...
     server_onupdate: Optional[FetchedValue] = ...
     index: Optional[bool] = ...
     unique: Optional[bool] = ...
@@ -152,7 +155,9 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[Union[FetchedValue, str, TextClause]] = ...,
+        server_default: Optional[
+            Union[FetchedValue, str, TextClause, ColumnElement[Any]]
+        ] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
@@ -173,7 +178,9 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[Union[FetchedValue, str, TextClause]] = ...,
+        server_default: Optional[
+            Union[FetchedValue, str, TextClause, ColumnElement[Any]]
+        ] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
@@ -196,7 +203,9 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[Union[FetchedValue, str, TextClause]] = ...,
+        server_default: Optional[
+            Union[FetchedValue, str, TextClause, ColumnElement[_TE]]
+        ] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
@@ -218,7 +227,9 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[Union[FetchedValue, str, TextClause]] = ...,
+        server_default: Optional[
+            Union[FetchedValue, str, TextClause, ColumnElement[_TE]]
+        ] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,

--- a/test/files/column_server_default_ticket_81.py
+++ b/test/files/column_server_default_ticket_81.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import true
+from sqlalchemy.orm import registry
+from sqlalchemy.sql import functions as func
+
+reg: registry = registry()
+
+
+@reg.mapped
+class A:
+    __tablename__ = "a"
+
+    b = Column(Boolean, nullable=False, server_default=true())
+    c = Column(DateTime, server_default=func.now(), nullable=False)
+
+    # EXPECTED: error: Cannot infer type argument 1 of "Column"
+    d = Column(Boolean, server_default=func.now(), nullable=False)


### PR DESCRIPTION
### Description
Add `server_default` typing for functions.

The test-case I've included assumes the locations based on #92.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
