### PR TITLE
Allow FunctionElement for Column server_default and server_onupdate

### DIFF
--- a/sqlalchemy-stubs/sql/schema.pyi
+++ b/sqlalchemy-stubs/sql/schema.pyi
@@ -29,6 +29,7 @@ from .elements import ClauseElement
 from .elements import ColumnClause
 from .elements import ColumnElement
 from .elements import TextClause
+from .functions import FunctionElement
 from .events import DDLEvents
 from .selectable import TableClause
 from .. import util
@@ -53,6 +54,9 @@ _CC = TypeVar("_CC", bound=CheckConstraint)
 _IDX = TypeVar("_IDX", bound=Index)
 _CP = TypeVar("_CP", bound=Computed)
 _ID = TypeVar("_ID", bound=Identity)
+
+_ServerDefaultType = Union[FetchedValue, str, TextClause, ColumnElement[_T]]
+_ServerOnUpdateType = Union[FetchedValue, FunctionElement]
 
 class SchemaItem(SchemaEventTarget, visitors.Visitable):
     __visit_name__: str = ...
@@ -140,10 +144,8 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
     primary_key: bool = ...
     nullable: bool = ...
     default: Optional[Any] = ...
-    server_default: Optional[
-        Union[FetchedValue, str, TextClause, ColumnElement[_TE]]
-    ] = ...
-    server_onupdate: Optional[FetchedValue] = ...
+    server_default: Optional[_ServerDefaultType[_TE]] = ...
+    server_onupdate: Optional[_ServerOnUpdateType] = ...
     index: Optional[bool] = ...
     unique: Optional[bool] = ...
     system: bool = ...
@@ -169,10 +171,8 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[
-            Union[FetchedValue, str, TextClause, ColumnElement[Any]]
-        ] = ...,
-        server_onupdate: Optional[FetchedValue] = ...,
+        server_default: Optional[_ServerDefaultType[Any]] = ...,
+        server_onupdate: Optional[_ServerOnUpdateType] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
         system: bool = ...,
@@ -192,10 +192,8 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[
-            Union[FetchedValue, str, TextClause, ColumnElement[Any]]
-        ] = ...,
-        server_onupdate: Optional[FetchedValue] = ...,
+        server_default: Optional[_ServerDefaultType[Any]] = ...,
+        server_onupdate: Optional[_ServerOnUpdateType] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
         system: bool = ...,
@@ -217,10 +215,8 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[
-            Union[FetchedValue, str, TextClause, ColumnElement[_TE]]
-        ] = ...,
-        server_onupdate: Optional[FetchedValue] = ...,
+        server_default: Optional[_ServerDefaultType[_TE]] = ...,
+        server_onupdate: Optional[_ServerOnUpdateType] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
         system: bool = ...,
@@ -241,10 +237,8 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[
-            Union[FetchedValue, str, TextClause, ColumnElement[_TE]]
-        ] = ...,
-        server_onupdate: Optional[FetchedValue] = ...,
+        server_default: Optional[_ServerDefaultType[_TE]] = ...,
+        server_onupdate: Optional[_ServerOnUpdateType] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
         system: bool = ...,

--- a/test/files/column_server_onupdate.py
+++ b/test/files/column_server_onupdate.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column
+from sqlalchemy.orm import registry
+from sqlalchemy.sql import functions as func
+from sqlalchemy.types import Integer
+
+reg: registry = registry()
+
+
+@reg.mapped
+class ColumnServerOnUpdateArgument:
+    __tablename__ = "onupdate"
+
+    # overload 1: (__name: str, *args, ...)
+    overload1: int = Column("name", server_onupdate=func.now(), nullable=False)
+    # overload 2: (*args, ...)
+    Column(server_onupdate=func.now(), nullable=False)
+    # overload 3: (__name: str, __type: _TE, *args, ...)
+    overload3 = Column("name", Integer, server_onupdate=func.now(), nullable=False)
+    # overload 4: (__type: _TE, *args, ...)
+    overload4 = Column(Integer, server_onupdate=func.now(), nullable=False)


### PR DESCRIPTION
Per the ["persistence techniques"](https://docs.sqlalchemy.org/en/14/orm/persistence_techniques.html#case-2-non-primary-key-returning-or-equivalent-is-not-supported-or-not-needed) section of SQLAlchemy's documentation, `Column` supports `FunctionElement`-typed values for `server_default` and `server_onupdate` arguments.

The `sqlalchemy-stubs` package also supports this use case, per [sql/schema.pyi](https://github.com/dropbox/sqlalchemy-stubs/blob/7c93cd31ef386b421b7aa9c595bb42580e47f61e/sqlalchemy-stubs/sql/schema.pyi#L94).

With this revision, I am proposing supporting this use case in `sqlalchemy2-stubs`.

If I'm wrong on any of this, please let me know!

And if not, please let me know what from the checklist below may apply to this type of PR. Thanks!

### Description
Add `FunctionElement` to the supported list of types for `Column`'s `server_default` and `server_onupdate` arguments.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix
    - [x] with unit tests
- [ ] A new feature implementation