### PR TITLE
Remove mypy dependency from the install requires.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ project_urls =
 python_requires = >=3.6
 
 install_requires =
-    mypy>=0.800
     typing-extensions>=3.7.4
 
 [options.data_files]


### PR DESCRIPTION


### Description
It's a peer dependency and only needed if you use the mypy plugin.
It's not needed for people not using mypy, and drags in a lot of weight.
People who want to use the mypy plugin will already have mypy installed
anyway.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
