### PR TITLE
don't use typing with ServerDefaultType

### DIFF
--- a/sqlalchemy-stubs/sql/schema.pyi
+++ b/sqlalchemy-stubs/sql/schema.pyi
@@ -54,7 +54,7 @@ _IDX = TypeVar("_IDX", bound=Index)
 _CP = TypeVar("_CP", bound=Computed)
 _ID = TypeVar("_ID", bound=Identity)
 
-_ServerDefaultType = Union[FetchedValue, str, TextClause, ColumnElement[_T]]
+_ServerDefaultType = Union[FetchedValue, str, TextClause, ColumnElement]
 
 class SchemaItem(SchemaEventTarget, visitors.Visitable):
     __visit_name__: str = ...
@@ -142,7 +142,7 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
     primary_key: bool = ...
     nullable: bool = ...
     default: Optional[Any] = ...
-    server_default: Optional[_ServerDefaultType[_TE]] = ...
+    server_default: Optional[_ServerDefaultType] = ...
     server_onupdate: Optional[FetchedValue] = ...
     index: Optional[bool] = ...
     unique: Optional[bool] = ...
@@ -169,7 +169,7 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[_ServerDefaultType[Any]] = ...,
+        server_default: Optional[_ServerDefaultType] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
@@ -190,7 +190,7 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[_ServerDefaultType[Any]] = ...,
+        server_default: Optional[_ServerDefaultType] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
@@ -213,7 +213,7 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[_ServerDefaultType[_TE]] = ...,
+        server_default: Optional[_ServerDefaultType] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,
@@ -235,7 +235,7 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_TE]):
         nullable: bool = ...,
         onupdate: Optional[Any] = ...,
         primary_key: bool = ...,
-        server_default: Optional[_ServerDefaultType[_TE]] = ...,
+        server_default: Optional[_ServerDefaultType] = ...,
         server_onupdate: Optional[FetchedValue] = ...,
         quote: Optional[bool] = ...,
         unique: Optional[bool] = ...,

--- a/test/files/column_server_default.py
+++ b/test/files/column_server_default.py
@@ -2,12 +2,12 @@ from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import DateTime
 from sqlalchemy import FetchedValue
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import literal_column
 from sqlalchemy import text
 from sqlalchemy import true
 from sqlalchemy.orm import registry
-from sqlalchemy.sql import functions as func
 
 reg: registry = registry()
 
@@ -19,8 +19,16 @@ class A:
     b = Column(Boolean, nullable=False, server_default=true())
     c = Column(DateTime, server_default=func.now(), nullable=False)
 
-    # EXPECTED_MYPY: Cannot infer type argument 1 of "Column"
-    d = Column(Boolean, server_default=func.now(), nullable=False)
+    # this is fine as we don't know anything about func.xyzq() (this was
+    # previously func.now(), but that's also untyped). The column type
+    # determines the type.
+    d = Column(Boolean, server_default=func.xyzq(), nullable=False)
+
+    # what would be *nice* to emit an error would be this, but this
+    # is really not important, people don't usually put types in functions
+    # as they are usually part of a bigger context where the type is known
+    # d = Column(Boolean, server_default=func.xyzq(type_=DateTime),
+    #  nullable=False)
 
     e = Column(DateTime, server_default="now()")
     f = Column(DateTime, server_default=text("now()"))


### PR DESCRIPTION
The server default is any expression that is passed as DDL
to the database and these usually don't have SQL types explicitly
stated.

With the code as is, pylance is complaining about this:

    Column(DateTime(), server_default=func.now())

and requiring I do this:

    Column(DateTime(), server_default=func.now(type_=DateTime))

people don't need to do that, server_defaults SQL type always comes
from the column type and doesn't normally need to be stated.

Also, column_server_default.py was importing "functions as func",
which is wrong. "func" is not a module it's a namespace object,
fixed that.