### PR TITLE
Fix: constructor argument of declarative_base is optional

### DIFF
--- a/sqlalchemy-stubs/orm/decl_api.pyi
+++ b/sqlalchemy-stubs/orm/decl_api.pyi
@@ -49,7 +49,7 @@ def declarative_base(
     mapper: Optional[Callable[..., Mapper]] = ...,
     cls: Union[type, Tuple[type, ...]] = ...,
     name: str = ...,
-    constructor: Callable[..., None] = ...,
+    constructor: Optional[Callable[..., None]] = ...,
     class_registry: Optional[MutableMapping[Any, Any]] = ...,
     metaclass: type = ...,
 ) -> type: ...


### PR DESCRIPTION
### Description

See sqlalchemy documentation:
https://docs.sqlalchemy.org/en/14/orm/mapping_api.html#sqlalchemy.orm.declarative_base.params.constructor

Fixes #192.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**

