### PR TITLE
fix(sql.schema): alias typing.Sequence -> _Sequence to avoid conflict with class Sequence

### DIFF
--- a/sqlalchemy-stubs/sql/schema.pyi
+++ b/sqlalchemy-stubs/sql/schema.pyi
@@ -8,7 +8,7 @@ from typing import List
 from typing import MutableMapping
 from typing import Optional
 from typing import overload
-from typing import Sequence
+from typing import Sequence as _Sequence
 from typing import Set
 from typing import Type
 from typing import TypeVar
@@ -74,7 +74,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
     fullname: str = ...
     implicit_returning: bool = ...
     comment: Optional[str] = ...
-    _prefixes: Sequence[str] = ...
+    _prefixes: _Sequence[str] = ...
     def __new__(cls: Type[_TAB], *args: Any, **kw: Any) -> _TAB: ...
     def __init__(self, *args: Any, **kw: Any) -> None: ...
     @property
@@ -343,7 +343,7 @@ class Sequence(
     data_type: Optional[_TE] = ...
     @overload
     def __init__(
-        self: Sequence[sqltypes.Integer],
+        self: _Sequence[sqltypes.Integer],
         name: str,
         start: Optional[int] = ...,
         increment: Optional[int] = ...,


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
alias typing.Sequence -> _Sequence to avoid conflict with class Sequence

Fixes: #209

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
