### PR TITLE
AsyncSession: correct (stream_)scalars arg name

### DIFF
--- a/sqlalchemy-stubs/ext/asyncio/session.pyi
+++ b/sqlalchemy-stubs/ext/asyncio/session.pyi
@@ -135,13 +135,13 @@ class _AsyncSessionProtocol(
     async def scalars(
         self,
         statement: Executable,
-        parameters: Optional[_ExecuteParams] = ...,
+        params: Optional[_ExecuteParams] = ...,
         execution_options: Optional[_ExecuteOptions] = ...,
     ) -> ScalarResult: ...
     async def stream_scalars(
         self,
         statement: Executable,
-        parameters: Optional[_ExecuteParams] = ...,
+        params: Optional[_ExecuteParams] = ...,
         execution_options: Optional[_ExecuteOptions] = ...,
     ) -> AsyncScalarResult: ...
     async def delete(self, instance: Any) -> None: ...
@@ -211,13 +211,13 @@ class _AsyncSessionTypingCommon(
     async def scalars(
         self,
         statement: Executable,
-        parameters: Optional[_ExecuteParams] = ...,
+        params: Optional[_ExecuteParams] = ...,
         execution_options: Optional[_ExecuteOptions] = ...,
     ) -> ScalarResult: ...
     async def stream_scalars(
         self,
         statement: Executable,
-        parameters: Optional[_ExecuteParams] = ...,
+        params: Optional[_ExecuteParams] = ...,
         execution_options: Optional[_ExecuteOptions] = ...,
     ) -> AsyncScalarResult: ...
     @classmethod

--- a/test/files/async_stuff.py
+++ b/test/files/async_stuff.py
@@ -15,13 +15,13 @@ as_session = async_scoped_session(SM, current_task)
 
 
 async def go() -> None:
-    r = await async_session.scalars(text("select 1"))
+    r = await async_session.scalars(text("select 1"), params=[])
     r.first()
-    sr = await async_session.stream_scalars(text("select 1"))
+    sr = await async_session.stream_scalars(text("select 1"), params=[])
     await sr.all()
-    r = await as_session.scalars(text("select 1"))
+    r = await as_session.scalars(text("select 1"), params=[])
     r.first()
-    sr = await as_session.stream_scalars(text("select 1"))
+    sr = await as_session.stream_scalars(text("select 1"), params=[])
     await sr.all()
 
     async with engine.connect() as conn:


### PR DESCRIPTION
The execute parameters argument is named 'params', not 'parameters'.
See the [`AsyncSession.scalars()`][1] and
[`AsyncSession.stream_scalars()`][2] implementations.

Fixes #230

[1]: https://github.com/sqlalchemy/sqlalchemy/blob/a84f474051cae710e33b3d9486194ed534fe0167/lib/sqlalchemy/ext/asyncio/session.py#L249-L256
[2]: https://github.com/sqlalchemy/sqlalchemy/blob/a84f474051cae710e33b3d9486194ed534fe0167/lib/sqlalchemy/ext/asyncio/session.py#L338-L345

### Checklist

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
