### PR TITLE
fix Insert.on_conflict_do_nothing return type

### DIFF
--- a/sqlalchemy-stubs/dialects/postgresql/dml.pyi
+++ b/sqlalchemy-stubs/dialects/postgresql/dml.pyi
@@ -35,7 +35,7 @@ class Insert(StandardInsert):
         ] = ...,
         index_elements: Optional[Sequence[Union[str, Column]]] = ...,
         index_where: Optional[Any] = ...,
-    ) -> "Index": ...
+    ) -> "Insert": ...
 
 insert: Any
 


### PR DESCRIPTION
Bump issue #212

Fix typing for dialects.postgresql.dml.Insert.on_conflict_do_nothing.


