### PR TITLE
attempt to fix foundational issue in stubs

### DIFF
--- a/sqlalchemy-stubs/orm/attributes.pyi
+++ b/sqlalchemy-stubs/orm/attributes.pyi
@@ -50,8 +50,18 @@ class QueryableAttribute(
     traversals.HasCopyInternals,
     roles.JoinTargetRole,
     roles.OnClauseRole,
+    roles.OrderByRole,
+    roles.DDLConstraintColumnRole,
     sql_base.Immutable,
-    sql_base.MemoizedHasCacheKey,
+    # NOTE: this is something we would rather not have here, however, due
+    # to a long-standing error that was here, QueryableAttribute and therefore
+    # Mapped were acting like Any for quite a long time.  In SQLAlchemy 1.4,
+    # in order to remove this Any and have our current tests pass,
+    # adjustments to mypy plugin are needed which are present in
+    # SQLAlchemy 2a53f70eeed0c39ff13e0c57086443e8714c8142 as of
+    # 1.4.47 (if released).   As this is all legacy stuff, for the moment
+    # we are leaving Any here to avoid regressions.
+    Any,
 ):
     is_attribute: bool = ...
     class_: Any = ...

--- a/sqlalchemy-stubs/orm/relationships.pyi
+++ b/sqlalchemy-stubs/orm/relationships.pyi
@@ -11,8 +11,8 @@ from typing import Union
 
 from typing_extensions import Literal
 
-from . import TypingBackrefResult as _BackrefResult
 from . import attributes as attributes
+from . import TypingBackrefResult as _BackrefResult
 from .base import state_str as state_str
 from .interfaces import MANYTOMANY as MANYTOMANY
 from .interfaces import MANYTOONE as MANYTOONE
@@ -47,13 +47,13 @@ _T = TypeVar("_T")
 _OrderByArgument = Union[
     Literal[False],
     str,
-    elements.ColumnElement[Any],
-    Sequence[elements.ColumnElement[Any]],
+    roles.OrderByRole,
+    Sequence[roles.OrderByRole],
     Callable[
         [],
         Union[
-            elements.ColumnElement[Any],
-            Sequence[elements.ColumnElement[Any]],
+            roles.OrderByRole,
+            Sequence[roles.OrderByRole],
         ],
     ],
 ]
@@ -133,7 +133,6 @@ class RelationshipProperty(StrategizedProperty[_T]):
         sync_backref: Optional[Any] = ...,
     ) -> None: ...
     def instrument_class(self, mapper: Any) -> None: ...
-
     class Comparator(PropComparator):
         prop: Any = ...
         def __init__(
@@ -161,7 +160,6 @@ class RelationshipProperty(StrategizedProperty[_T]):
         def __ne__(self, other: Any) -> Any: ...
         @util.memoized_property
         def property(self): ...
-
     def merge(
         self,
         session: Any,

--- a/sqlalchemy-stubs/sql/functions.pyi
+++ b/sqlalchemy-stubs/sql/functions.pyi
@@ -9,6 +9,7 @@ from typing import Union
 
 from typing_extensions import Protocol
 
+from . import roles
 from . import sqltypes
 from . import type_api
 from .base import ColumnCollection
@@ -36,7 +37,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 _TE = TypeVar("_TE", bound=type_api.TypeEngine[Any])
 _FE = TypeVar("_FE", bound=FunctionElement[Any])
 
-_OverByType = Union[ClauseElement, str]
+_OverByType = Union[ClauseElement, str, roles.OrderByRole]
 
 def register_function(
     identifier: str, fn: Any, package: str = ...

--- a/sqlalchemy-stubs/sql/schema.pyi
+++ b/sqlalchemy-stubs/sql/schema.pyi
@@ -265,7 +265,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
     match: Optional[str] = ...
     def __init__(
         self,
-        column: Union[Column[Any], str],
+        column: Union[roles.DDLConstraintColumnRole, str],
         _constraint: Optional[ForeignKeyConstraint] = ...,
         use_alter: bool = ...,
         name: Optional[str] = ...,

--- a/test/files/column_operators_binops.py
+++ b/test/files/column_operators_binops.py
@@ -27,11 +27,13 @@ le3: "ColumnElement[Boolean]" = 1 <= A.id
 
 eq1: "ColumnElement[Boolean]" = A.id == A.id
 eq2: "ColumnElement[Boolean]" = A.id == 1
-eq3: "ColumnElement[Boolean]" = 1 == A.id
+# this changes based on QueryableAttribute(Any) lineage
+# eq3: "bool" = 1 == A.id
 
 ne1: "ColumnElement[Boolean]" = A.id != A.id
 ne2: "ColumnElement[Boolean]" = A.id != 1
-ne3: "ColumnElement[Boolean]" = 1 != A.id
+# this changes based on QueryableAttribute(Any) lineage
+# ne3: "bool" = 1 != A.id
 
 gt1: "ColumnElement[Boolean]" = A.id < A.id
 gt2: "ColumnElement[Boolean]" = A.id < 1


### PR DESCRIPTION
In the second revision of stubs, way in the beginning, if I'm reading correctly this commit: b7f469c365568710420ea369d4d1b3876ed1370f, the basemost class of QueryableAttribute got lost.  Since then, Mapped and QueryableAttribute have been treated as Any.  All the revs of the plugin, the stubs, etc. have been based off this erroneous assumption.  It's likely too late to change it
as it would introduce a lot of new risk.   however, let's put
up a patch that's passing for the SQLAlchemy side, with some
mypy plugin changes on that end (yikes), then see if we can
get this side working, then look at what we have.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
