### PR TITLE
Fix `RowMapping.__getitem__` to reflect that it supports `Column`s or strings

### DIFF
--- a/sqlalchemy-stubs/engine/row.pyi
+++ b/sqlalchemy-stubs/engine/row.pyi
@@ -10,10 +10,12 @@ from typing import Sequence
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
+from typing import Union
 from typing import ValuesView
 
 from .result import ResultMetaData
 from .result import RMKeyView
+from ..sql.schema import Column
 
 _T = TypeVar("_T")
 
@@ -80,8 +82,8 @@ class ROMappingView(  # type: ignore[misc]
     def __eq__(self, other: Any) -> bool: ...
     def __ne__(self, other: Any) -> bool: ...
 
-class RowMapping(BaseRow, Mapping[str, Any]):
-    def __getitem__(self, key: str) -> Any: ...
+class RowMapping(BaseRow, Mapping[Union[str, Column[Any]], Any]):
+    def __getitem__(self, key: Union[str, Column[Any]]) -> Any: ...
     def __iter__(self) -> Iterator[str]: ...
     def __len__(self) -> int: ...
     def __contains__(self, key: Any) -> bool: ...


### PR DESCRIPTION
### Description

Found this while working on resolving `SADeprecationWarning`s on 1.4.x. We did a lot of `row[my_table.c.my_col]` and I'm replacing it with `row._mapping[my_table.c.my_col]`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
