### PR TITLE
Restore default for column_valued name parameter

### DIFF
--- a/sqlalchemy-stubs/sql/functions.pyi
+++ b/sqlalchemy-stubs/sql/functions.pyi
@@ -59,7 +59,7 @@ class FunctionElement(  # type: ignore[misc]
     ) -> ScalarFunctionColumn[_TE]: ...
     def table_valued(self, *expr: Any, **kw: Any) -> TableValuedAlias: ...  # type: ignore[override]
     def column_valued(
-        self, name: Optional[Any], joins_implicitly: bool = False
+        self, name: Optional[Any] = ..., joins_implicitly: bool = False
     ) -> TableValuedColumn[Any]: ...
     @property
     def columns(self) -> ColumnCollection[ColumnElement[Any]]: ...  # type: ignore[override]


### PR DESCRIPTION
### Description

Commit 20436f71520e26e1f6fd81836ee7e283d69db8df (#258) incorrectly removed this default, which is needed to accept calls without a `name`, i.e., `.column_valued()`.

- Fixes #259.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
