### PR TITLE
Add ColumnOperators.__hash__ (fixes #262)

### DIFF
--- a/sqlalchemy-stubs/sql/operators.pyi
+++ b/sqlalchemy-stubs/sql/operators.pyi
@@ -111,6 +111,10 @@ class ColumnOperators(Operators[ColumnElement[_TE]], Generic[_TE]):
     def __lt__(self, other: Any) -> ColumnElement[sqltypes.Boolean]: ...
     def __le__(self, other: Any) -> ColumnElement[sqltypes.Boolean]: ...
     def __eq__(self, other: Any) -> ColumnElement[sqltypes.Boolean]: ...  # type: ignore[override]
+    # ColumnOperators defines an __eq__ so it must explicitly declare also
+    # an hash or it's set to None by python:
+    # https://docs.python.org/3/reference/datamodel.html#object.__hash__
+    def __hash__(self) -> int: ...
     def __ne__(self, other: Any) -> ColumnElement[sqltypes.Boolean]: ...  # type: ignore[override]
     def is_distinct_from(
         self, other: Any


### PR DESCRIPTION
### Description

Added `__hash__` like it's [done] in SQLAlchemy 2.0.

### Checklist

This pull request is:

- [x] A short code fix
	- [x] please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- [x] Please include: `Fixes: #<issue number>` in the commit message
	- [ ] please include tests.   one line code fixes without tests will not be accepted.

[done]: https://github.com/sqlalchemy/sqlalchemy/blob/02472e8b65ac4062f2c3e7cee19608c801fba14c/lib/sqlalchemy/sql/operators.py#L572-L574